### PR TITLE
Find and link settings data for block label

### DIFF
--- a/src/Blip/Backoffice/app/Backoffice/js/blip.resource.ts
+++ b/src/Blip/Backoffice/app/Backoffice/js/blip.resource.ts
@@ -31,10 +31,13 @@ export class BlipResource {
           const blockConfig = sourceProperty.config.blocks.find(b => b.contentElementTypeKey === block.contentTypeKey);
           const contentType = scaffolds[block.contentTypeKey];
 
+          const settingsUdi = sourceProperty.value.layout[sourceProperty.editor].find(l => l.contentUdi === block.udi).settingsUdi || '';
+          const settingsData = sourceProperty.value.settingsData.find(d => d.udi === settingsUdi);
+
           if (blockConfig.label) {
             const labelVars = Object.assign({
               '$contentTypeName': contentType.contentTypeName,
-              '$settings': block.settingsTypeKey ? scaffolds[block.settingsTypeKey] : {},
+              '$settings': settingsData || {},
               '$layout': block.layout || {},
               '$index': idx + 1,
             }, block);

--- a/src/Blip/Backoffice/app/Backoffice/js/blip.resource.ts
+++ b/src/Blip/Backoffice/app/Backoffice/js/blip.resource.ts
@@ -31,8 +31,8 @@ export class BlipResource {
           const blockConfig = sourceProperty.config.blocks.find(b => b.contentElementTypeKey === block.contentTypeKey);
           const contentType = scaffolds[block.contentTypeKey];
 
-          const settingsUdi = sourceProperty.value.layout[sourceProperty.editor].find(l => l.contentUdi === block.udi).settingsUdi || '';
-          const settingsData = sourceProperty.value.settingsData.find(d => d.udi === settingsUdi);
+          const layoutData = sourceProperty.value.layout[sourceProperty.editor].find(l => l.contentUdi === block.udi);
+          const settingsData = layoutData && layoutData.settingsUdi ? sourceProperty.value.settingsData.find(d => d.udi === layoutData.settingsUdi) : {};
 
           if (blockConfig.label) {
             const labelVars = Object.assign({


### PR DESCRIPTION
Issue reference: #6 

This PR finds the settings node from the source value data and loads it in during the label configuration, meaning that blocks listed in the block list picker editor will reflect the settings data defined on the label.

Based on the example in the issue #6 -

Instead of seeing:
![image](https://github.com/nathanwoulfe/Blip/assets/6873029/33b09095-4993-45d3-ae42-1d8bb2e060af)

You would now see:
![image](https://github.com/nathanwoulfe/Blip/assets/6873029/1f9ad866-37f8-441f-8fe0-24653c74ed88)
